### PR TITLE
fix: Keep unix style line breaks when checking out on windows.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.css text eol=lf
+*.js text eol=lf


### PR DESCRIPTION
When checking out on windows line breaks can be changed to CRLF, depending on Git configuration, and this leads to this errors, just by running **npm run serve**:

![image](https://user-images.githubusercontent.com/7357806/38473629-1787d7d8-3b8b-11e8-9741-b2177bdec057.png)

This git local config ensures that when checking out .css and .js files they keep the LF line breaks, so neither eslint nor minification are triggered by spurious file changes.