### PR TITLE
problem with pug compiler, doesn't work well cross platform, by using…

### DIFF
--- a/build/pug.js
+++ b/build/pug.js
@@ -83,9 +83,9 @@ const compileHtml = () => {
       const html = compile(view, './pug/layout/')
       let file
       if (version === 'ajax') {
-        file = view.replace('pug/', '').replace('.pug', '.html')
+        file = view.replace(`pug${path.sep}`, '').replace('.pug', '.html')
       } else {
-        file = view.replace('pug/views/', '').replace('.pug', '.html')
+        file = view.replace(`pug${path.sep}views${path.sep}`, '').replace('.pug', '.html')
       }
       // Create tree
       mkdirp.sync(resolve(dest, dirname(file)))


### PR DESCRIPTION
hello, I noticed that
`npm run pug`
doesn't work properly on windows platform,
this tiny fix sets the slash correctly:
`path.sep`
I hope this will help next one get started quicker and easier without tearing their hair too much.

I appreciate all your work, best of luck and i hope i helped.
