### PR TITLE
Escaped base64 images routes

### DIFF
--- a/build/vendors.js
+++ b/build/vendors.js
@@ -111,12 +111,14 @@ const findVendors = () => {
 const copyFiles = (files, dest) => {
   files.forEach((file) => {
     let dir
-    file.filetype !== 'other' ? dir = resolve(dest, file.name, file.filetype) : dir = resolve(dest, file.name, dirname(file.src))
-    mkdirp.sync(dir)
-    fs.createReadStream(file.absolute).pipe(fs.createWriteStream(resolve(dir, basename(file.src))))
+    if(!file.src.indexOf(';base64,')) {
+      file.filetype !== 'other' ? dir = resolve(dest, file.name, file.filetype) : dir = resolve(dest, file.name, dirname(file.src))
+      mkdirp.sync(dir)
+      fs.createReadStream(file.absolute).pipe(fs.createWriteStream(resolve(dir, basename(file.src))))
 
-    if (fs.existsSync(`${file.absolute}.map`)) {
-      fs.createReadStream(`${file.absolute}.map`).pipe(fs.createWriteStream(resolve(dir, `${basename(file.src)}.map`)))
+      if (fs.existsSync(`${file.absolute}.map`)) {
+        fs.createReadStream(`${file.absolute}.map`).pipe(fs.createWriteStream(resolve(dir, `${basename(file.src)}.map`)))
+      }
     }
   })
 }


### PR DESCRIPTION
### Introduction

CoreUI is the best admin template I've been able to test. One way to thank is to find and fix bugs.

In this case, I have proceeded to install the Summernote as WYSIWYG editor, but when making a build through npm run build, this is the output that appears in the console:

```
> @coreui/coreui-free-bootstrap-admin-template@2.1.11 build {route-to-project}
> npm-run-all build-clean build-copy build-vendors


> @coreui/coreui-free-bootstrap-admin-template@2.1.11 build-clean {route-to-project}
> rimraf dist


> @coreui/coreui-free-bootstrap-admin-template@2.1.11 build-copy {route-to-project}
> copyfiles -a -e "src/scss/**/*" -u 1 "src/**/*" dist/


> @coreui/coreui-free-bootstrap-admin-template@2.1.11 build-vendors {route-to-project}
> node build/vendors.js

events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open '{route-to-project}/node_modules/summernote/dist/data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASAgMAAAAroGbEAAAACVBMVEUAAIj4+Pjp6ekKlAqjAAAAAXRSTlMAQObYZgAAAAFiS0dEAIgFHUgAAAAJcEhZcwAACxMAAAsTAQCanBgAAAAHdElNRQfYAR0BKhmnaJzPAAAAG0lEQVQI12NgAAOtVatWMTCohoaGUY+EmIkEAEruEzK2J7tvAAAAAElFTkSuQmCC''
Emitted 'error' event at:
    at lazyFs.open (internal/fs/streams.js:115:12)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @coreui/coreui-free-bootstrap-admin-template@2.1.11 build-vendors: `node build/vendors.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @coreui/coreui-free-bootstrap-admin-template@2.1.11 build-vendors script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/wincrash32/.npm/_logs/2019-03-13T11_32_37_770Z-debug.log
ERROR: "build-vendors" exited with 1.
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @coreui/coreui-free-bootstrap-admin-template@2.1.11 build: `npm-run-all build-clean build-copy build-vendors`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @coreui/coreui-free-bootstrap-admin-template@2.1.11 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/wincrash32/.npm/_logs/2019-03-13T11_32_37_796Z-debug.log
```

### PR Checklist
- [x] This PR follows our guidelines: https://github.com/coreui/coreui-free-bootstrap-admin-template/blob/master/CONTRIBUTING.md#pull-requests
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes

### Does this PR introduce a breaking change?
- [ ] Yes
- [x] No