### PR TITLE
The README file in this repo has a bad link - [404:NotFound] - CONTRI…

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The documentation for the CoreUI Free Bootstrap Admin Template is hosted at our 
 
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/coreui/coreui-free-bootstrap-admin-template/blob/master/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
+Please read through our [contributing guidelines](https://github.com/coreui/coreui-free-bootstrap-admin-template/blob/master/.github/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
 
 Editor preferences are available in the [editor config](https://github.com/coreui/coreui-free-bootstrap-admin-template/blob/master/.editorconfig) for easy use in common text editors. Read more and download plugins at <http://editorconfig.org>.
 


### PR DESCRIPTION
…BUTING.md

Resolved issue: #555


The markup version of the readme that is displayed for the main page in this repo contains the following link:

Status code [404:NotFound] - Link: https://github.com/coreui/coreui-free-bootstrap-admin-template/blob/master/CONTRIBUTING.md

It should be: https://github.com/coreui/coreui-free-bootstrap-admin-template/blob/master/.github/CONTRIBUTING.md


**Extra**

This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder


Re-check this Repo via: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fcoreui%2fcoreui-free-bootstrap-admin-template
Check all Repos for this GitHub account: http://githubreadmechecker.com/Home/Search?User=coreui



--

I (a human) verified that this link is broken and have manually logged this Issue (i.e. this Issue has not been created by a bot).
If this has been in any way helpful then please consider giving the above Repo a Star.

If you have any feedback on the information provided here, or on the tool itself, then please feel free to share your thoughts and pass on the feedback, or log an “Issue”.